### PR TITLE
Make medium date format consistent across pt and pt-* locales consistent

### DIFF
--- a/main/pt-AO/ca-gregorian.json
+++ b/main/pt-AO/ca-gregorian.json
@@ -311,7 +311,7 @@
             "dateFormats": {
               "full": "EEEE, d 'de' MMMM 'de' y",
               "long": "d 'de' MMMM 'de' y",
-              "medium": "dd/MM/y",
+              "medium": "d 'de' MMM 'de' y",
               "short": "dd/MM/yy"
             },
             "timeFormats": {

--- a/main/pt-CH/ca-gregorian.json
+++ b/main/pt-CH/ca-gregorian.json
@@ -311,7 +311,7 @@
             "dateFormats": {
               "full": "EEEE, d 'de' MMMM 'de' y",
               "long": "d 'de' MMMM 'de' y",
-              "medium": "dd/MM/y",
+              "medium": "d 'de' MMM 'de' y",
               "short": "dd/MM/yy"
             },
             "timeFormats": {

--- a/main/pt-CV/ca-gregorian.json
+++ b/main/pt-CV/ca-gregorian.json
@@ -311,7 +311,7 @@
             "dateFormats": {
               "full": "EEEE, d 'de' MMMM 'de' y",
               "long": "d 'de' MMMM 'de' y",
-              "medium": "dd/MM/y",
+              "medium": "d 'de' MMM 'de' y",
               "short": "dd/MM/yy"
             },
             "timeFormats": {

--- a/main/pt-GQ/ca-gregorian.json
+++ b/main/pt-GQ/ca-gregorian.json
@@ -311,7 +311,7 @@
             "dateFormats": {
               "full": "EEEE, d 'de' MMMM 'de' y",
               "long": "d 'de' MMMM 'de' y",
-              "medium": "dd/MM/y",
+              "medium": "d 'de' MMM 'de' y",
               "short": "dd/MM/yy"
             },
             "timeFormats": {

--- a/main/pt-GW/ca-gregorian.json
+++ b/main/pt-GW/ca-gregorian.json
@@ -311,7 +311,7 @@
             "dateFormats": {
               "full": "EEEE, d 'de' MMMM 'de' y",
               "long": "d 'de' MMMM 'de' y",
-              "medium": "dd/MM/y",
+              "medium": "d 'de' MMM 'de' y",
               "short": "dd/MM/yy"
             },
             "timeFormats": {

--- a/main/pt-LU/ca-gregorian.json
+++ b/main/pt-LU/ca-gregorian.json
@@ -311,7 +311,7 @@
             "dateFormats": {
               "full": "EEEE, d 'de' MMMM 'de' y",
               "long": "d 'de' MMMM 'de' y",
-              "medium": "dd/MM/y",
+              "medium": "d 'de' MMM 'de' y",
               "short": "dd/MM/yy"
             },
             "timeFormats": {

--- a/main/pt-MO/ca-gregorian.json
+++ b/main/pt-MO/ca-gregorian.json
@@ -311,7 +311,7 @@
             "dateFormats": {
               "full": "EEEE, d 'de' MMMM 'de' y",
               "long": "d 'de' MMMM 'de' y",
-              "medium": "dd/MM/y",
+              "medium": "d 'de' MMM 'de' y",
               "short": "dd/MM/yy"
             },
             "timeFormats": {

--- a/main/pt-MZ/ca-gregorian.json
+++ b/main/pt-MZ/ca-gregorian.json
@@ -311,7 +311,7 @@
             "dateFormats": {
               "full": "EEEE, d 'de' MMMM 'de' y",
               "long": "d 'de' MMMM 'de' y",
-              "medium": "dd/MM/y",
+              "medium": "d 'de' MMM 'de' y",
               "short": "dd/MM/yy"
             },
             "timeFormats": {

--- a/main/pt-PT/ca-gregorian.json
+++ b/main/pt-PT/ca-gregorian.json
@@ -311,7 +311,7 @@
             "dateFormats": {
               "full": "EEEE, d 'de' MMMM 'de' y",
               "long": "d 'de' MMMM 'de' y",
-              "medium": "dd/MM/y",
+              "medium": "d 'de' MMM 'de' y",
               "short": "dd/MM/yy"
             },
             "timeFormats": {

--- a/main/pt-ST/ca-gregorian.json
+++ b/main/pt-ST/ca-gregorian.json
@@ -311,7 +311,7 @@
             "dateFormats": {
               "full": "EEEE, d 'de' MMMM 'de' y",
               "long": "d 'de' MMMM 'de' y",
-              "medium": "dd/MM/y",
+              "medium": "d 'de' MMM 'de' y",
               "short": "dd/MM/yy"
             },
             "timeFormats": {

--- a/main/pt-TL/ca-gregorian.json
+++ b/main/pt-TL/ca-gregorian.json
@@ -311,7 +311,7 @@
             "dateFormats": {
               "full": "EEEE, d 'de' MMMM 'de' y",
               "long": "d 'de' MMMM 'de' y",
-              "medium": "dd/MM/y",
+              "medium": "d 'de' MMM 'de' y",
               "short": "dd/MM/yy"
             },
             "timeFormats": {


### PR DESCRIPTION
The definition for gregorian medium date format for pt was different than pt-*.
This PR will make all consistent and according to pt format.